### PR TITLE
feat: use showSnackbarMessage in viewmodel

### DIFF
--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModelTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModelTest.kt
@@ -18,13 +18,17 @@ package com.google.samples.apps.sunflower.viewmodels
 
 import android.arch.persistence.room.Room
 import android.support.test.InstrumentationRegistry
+import android.support.test.annotation.UiThreadTest
+import com.google.samples.apps.sunflower.R
 import com.google.samples.apps.sunflower.data.AppDatabase
 import com.google.samples.apps.sunflower.data.GardenPlantingRepository
 import com.google.samples.apps.sunflower.data.PlantRepository
 import com.google.samples.apps.sunflower.utilities.getValue
 import com.google.samples.apps.sunflower.utilities.testPlant
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -53,5 +57,13 @@ class PlantDetailViewModelTest {
     @Throws(InterruptedException::class)
     fun testDefaultValues() {
         assertFalse(getValue(viewModel.isPlanted))
+    }
+
+    @Test
+    @UiThreadTest
+    fun testSnackbarMessage_AddedPlantToGardenString() {
+        assertNotEquals(viewModel.snackbarText.value, R.string.added_plant_to_garden)
+        viewModel.showSnackbarMessage(R.string.added_plant_to_garden)
+        assertEquals(viewModel.snackbarText.value, R.string.added_plant_to_garden)
     }
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import android.databinding.DataBindingUtil
 import android.os.Build
 import android.os.Bundle
+import android.support.annotation.StringRes
 import android.support.design.widget.Snackbar
 import android.support.v4.app.Fragment
 import android.support.v4.app.ShareCompat
@@ -34,6 +35,7 @@ import android.view.ViewGroup
 
 import com.google.samples.apps.sunflower.databinding.FragmentPlantDetailBinding
 import com.google.samples.apps.sunflower.utilities.InjectorUtils
+import com.google.samples.apps.sunflower.utilities.SnackbarMessage
 import com.google.samples.apps.sunflower.viewmodels.PlantDetailViewModel
 
 /**
@@ -60,9 +62,15 @@ class PlantDetailFragment : Fragment() {
             setLifecycleOwner(this@PlantDetailFragment)
             fab.setOnClickListener { view ->
                 plantDetailViewModel.addPlantToGarden()
-                Snackbar.make(view, R.string.added_plant_to_garden, Snackbar.LENGTH_LONG).show()
+                plantDetailViewModel.showSnackbarMessage(R.string.added_plant_to_garden)
             }
         }
+
+        plantDetailViewModel.snackbarText.observe(viewLifecycleOwner, object : SnackbarMessage.SnackbarObserver {
+            override fun onNewMessage(@StringRes snackbarMessageResourceId: Int) {
+                Snackbar.make(binding.fab, getString(snackbarMessageResourceId), Snackbar.LENGTH_LONG).show()
+            }
+        })
 
         plantDetailViewModel.plant.observe(this, Observer { plant ->
             shareText = if (plant == null) {

--- a/app/src/main/java/com/google/samples/apps/sunflower/utilities/SingleLiveEvent.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/utilities/SingleLiveEvent.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.sunflower.utilities
+
+import android.arch.lifecycle.LifecycleOwner
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.Observer
+import android.support.annotation.MainThread
+import android.util.Log
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A lifecycle-aware observable that sends only new updates after subscription, used for events like
+ * navigation and Snackbar messages.
+ *
+ *
+ * This avoids a common problem with events: on configuration change (like rotation) an update
+ * can be emitted if the observer is active. This LiveData only calls the observable if there's an
+ * explicit call to setValue() or call().
+ *
+ *
+ * Note that only one observer is going to be notified of changes.
+ */
+open class SingleLiveEvent<T> : MutableLiveData<T>() {
+
+    private val mPending = AtomicBoolean(false)
+
+    @MainThread
+    override fun observe(owner: LifecycleOwner, observer: Observer<T>) {
+
+        if (hasActiveObservers()) {
+            Log.w(TAG, "Multiple observers registered but only one will be notified of changes.")
+        }
+
+        // Observe the internal MutableLiveData
+        super.observe(owner, Observer { t ->
+            if (mPending.compareAndSet(true, false)) {
+                observer.onChanged(t)
+            }
+        })
+    }
+
+    @MainThread
+    override fun setValue(t: T?) {
+        mPending.set(true)
+        super.setValue(t)
+    }
+
+    /**
+     * Used for cases where T is Void, to make calls cleaner.
+     */
+    @MainThread
+    fun call() {
+        value = null
+    }
+
+    companion object {
+
+        private val TAG = "SingleLiveEvent"
+    }
+}

--- a/app/src/main/java/com/google/samples/apps/sunflower/utilities/SnackbarMessage.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/utilities/SnackbarMessage.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.sunflower.utilities
+
+import android.arch.lifecycle.LifecycleOwner
+import android.arch.lifecycle.Observer
+import android.support.annotation.StringRes
+
+/**
+ * A SingleLiveEvent used for Snackbar messages. Like a [SingleLiveEvent] but also prevents
+ * null messages and uses a custom observer.
+ *
+ *
+ * Note that only one observer is going to be notified of changes.
+ */
+class SnackbarMessage : SingleLiveEvent<Int>() {
+
+    fun observe(owner: LifecycleOwner, observer: SnackbarObserver) {
+        super.observe(owner, Observer { t ->
+            if (t == null) {
+                return@Observer
+            }
+            observer.onNewMessage(t)
+        })
+    }
+
+    interface SnackbarObserver {
+        /**
+         * Called when there is a new message to be shown.
+         * @param snackbarMessageResourceId The new message, non-null.
+         */
+        fun onNewMessage(@StringRes snackbarMessageResourceId: Int)
+    }
+}

--- a/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModel.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModel.kt
@@ -19,10 +19,12 @@ package com.google.samples.apps.sunflower.viewmodels
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.Transformations
 import android.arch.lifecycle.ViewModel
+import android.support.annotation.StringRes
 import com.google.samples.apps.sunflower.PlantDetailFragment
 import com.google.samples.apps.sunflower.data.GardenPlantingRepository
 import com.google.samples.apps.sunflower.data.Plant
 import com.google.samples.apps.sunflower.data.PlantRepository
+import com.google.samples.apps.sunflower.utilities.SnackbarMessage
 
 /**
  * The ViewModel used in [PlantDetailFragment].
@@ -35,6 +37,7 @@ class PlantDetailViewModel(
 
     val isPlanted: LiveData<Boolean>
     val plant: LiveData<Plant>
+    val snackbarText = SnackbarMessage()
 
     init {
 
@@ -50,5 +53,9 @@ class PlantDetailViewModel(
 
     fun addPlantToGarden() {
         gardenPlantingRepository.createGardenPlanting(plantId)
+    }
+
+    fun showSnackbarMessage(@StringRes message: Int?) {
+        snackbarText.value = message
     }
 }


### PR DESCRIPTION
Instead of show snackbar in fragment directly. Prepare for do remove garden planting action later (control delete action and show message action both in viewmodel).