### PR TITLE
Ref PlantDao to return LiveData type, change to nullable type

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/data/PlantDao.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/PlantDao.kt
@@ -34,7 +34,7 @@ interface PlantDao {
     fun getPlantsWithGrowZoneNumber(growZoneNumber: Int): LiveData<List<Plant>>
 
     @Query("SELECT * FROM plants WHERE id = :plantId")
-    fun getPlant(plantId: String): LiveData<Plant>
+    fun getPlant(plantId: String): LiveData<Plant?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertAll(plants: List<Plant>)

--- a/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModel.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModel.kt
@@ -38,7 +38,7 @@ class PlantDetailViewModel(
 ) : ViewModel() {
 
     val isPlanted: LiveData<Boolean>
-    val plant: LiveData<Plant>
+    val plant: LiveData<Plant?>
 
     /**
      * Cancel all coroutines when the ViewModel is cleared.


### PR DESCRIPTION
According to the SQL statement, the query from the database by id does not necessarily return a value. Therefore, the generics in LiveData should be nullable.

This is also confirmed in the code(`PlantDao_Impl`) generated by the Room, as follows:

![image](https://user-images.githubusercontent.com/6247142/58895079-bb741f00-8725-11e9-8f80-c442cc6f6ab3.png)

In addition, in the `PlantDetailFragment` class will also determine whether the plant is null, as follows:

![image](https://user-images.githubusercontent.com/6247142/58895560-c7141580-8726-11e9-86d3-2dc267131703.png)
