### PR TITLE
rearrange method's order

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
@@ -33,14 +33,14 @@ import com.google.samples.apps.sunflower.databinding.ListItemPlantBinding
  */
 class PlantAdapter : ListAdapter<Plant, RecyclerView.ViewHolder>(PlantDiffCallback()) {
 
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return PlantViewHolder(ListItemPlantBinding.inflate(
+                LayoutInflater.from(parent.context), parent, false))
+    }
+
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         val plant = getItem(position)
         (holder as PlantViewHolder).bind(plant)
-    }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        return PlantViewHolder(ListItemPlantBinding.inflate(
-            LayoutInflater.from(parent.context), parent, false))
     }
 
     class PlantViewHolder(


### PR DESCRIPTION
I just rearranged the order of the method because it would be easier to see that the first called 'method' was in the first position. (just like GardenPlantingAdapter.kt)