### PR TITLE
Use ViewModelProvider.Factory instead of ViewModelProvider.NewInstanceFactory

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/GardenPlantingListViewModelFactory.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/GardenPlantingListViewModelFactory.kt
@@ -26,7 +26,7 @@ import com.google.samples.apps.sunflower.data.GardenPlantingRepository
  */
 class GardenPlantingListViewModelFactory(
     private val repository: GardenPlantingRepository
-) : ViewModelProvider.NewInstanceFactory() {
+) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModelFactory.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModelFactory.kt
@@ -31,7 +31,7 @@ class PlantDetailViewModelFactory(
     private val plantRepository: PlantRepository,
     private val gardenPlantingRepository: GardenPlantingRepository,
     private val plantId: String
-) : ViewModelProvider.NewInstanceFactory() {
+) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {


### PR DESCRIPTION
It makes more sense for custom ViewModel factories to implement `ViewModelProvider.Factory` instead of inheriting `ViewModelProvider.NewInstanceFactory` because they don’t use the implementations of NewInstanceFactory.