### PR TITLE
using const string for tag to prevent issues with obfuscation

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/workers/SeedDatabaseWorker.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/workers/SeedDatabaseWorker.kt
@@ -52,6 +52,6 @@ class SeedDatabaseWorker(
     }
 
     companion object {
-        private val TAG = SeedDatabaseWorker::class.java.simpleName
+        private const val TAG = "SeedDatabaseWorker"
     }
 }


### PR DESCRIPTION
(I am practicing committing)
I liked the idea of using
`this::class.java.enclosingClass?.simpleName`
from within the companion object to define the tag value. however, i did research and found that using `simpleName` etc. can produce problems if you use obfuscation. 

further, the documentation example [here](https://developer.android.com/reference/android/util/Log) uses a string value. there would probably never be an issue, but since it is android's official app, let's be pedantic together :)