### PR TITLE
Clear my garden end delete plant

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,9 @@ apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    dataBinding {
-        enabled = true
+    buildToolsVersion rootProject.buildToolsVersion
+    buildFeatures {
+        dataBinding  true
     }
     defaultConfig {
         applicationId "com.google.samples.apps.sunflower"
@@ -33,6 +34,11 @@ android {
         versionCode 1
         versionName "0.1.6"
         vectorDrawables.useSupportLibrary true
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = ["room.incremental" : "true"]
+            }
+        }
     }
     buildTypes {
         release {
@@ -54,10 +60,14 @@ dependencies {
     kapt "androidx.room:room-compiler:$rootProject.roomVersion"
     kapt "com.github.bumptech.glide:compiler:$rootProject.glideVersion"
     implementation "androidx.appcompat:appcompat:$rootProject.appCompatVersion"
+    //noinspection GradleDependency
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.constraintLayoutVersion"
     implementation "androidx.core:core-ktx:$rootProject.ktxVersion"
     implementation "androidx.fragment:fragment-ktx:$rootProject.fragmentVersion"
-    implementation "androidx.lifecycle:lifecycle-extensions:$rootProject.lifecycleVersion"
+    // The APIs in lifecycle-extensions have been deprecated.
+    // Instead, add dependencies for the specific Lifecycle artifacts you need.
+    // https://developer.android.com/jetpack/androidx/releases/lifecycle#declaring_dependencies
+    //implementation "androidx.lifecycle:lifecycle-extensions:$rootProject.lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$rootProject.lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$rootProject.lifecycleVersion"
     implementation "androidx.navigation:navigation-fragment-ktx:$rootProject.navigationVersion"

--- a/app/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
@@ -17,13 +17,12 @@
 package com.google.samples.apps.sunflower
 
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.snackbar.Snackbar
 import com.google.samples.apps.sunflower.adapters.GardenPlantingAdapter
 import com.google.samples.apps.sunflower.adapters.PLANT_LIST_PAGE_INDEX
 import com.google.samples.apps.sunflower.databinding.FragmentGardenBinding
@@ -50,11 +49,27 @@ class GardenFragment : Fragment() {
         binding.addPlant.setOnClickListener {
             navigateToPlantListPage()
         }
+        // enable the top menu in the fragment
+        setHasOptionsMenu(true)
 
         subscribeUi(adapter, binding)
         return binding.root
     }
-
+    // AS icon for Clear Garden
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.menu_plant_list, menu)
+    }
+    // AS Clear Garden
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.filter_zone -> {
+                viewModel.clearGarden()
+                Snackbar.make(binding.root,R.string.garden_cleared, Snackbar.LENGTH_LONG).show()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
     private fun subscribeUi(adapter: GardenPlantingAdapter, binding: FragmentGardenBinding) {
         viewModel.plantAndGardenPlantings.observe(viewLifecycleOwner) { result ->
             binding.hasPlantings = !result.isNullOrEmpty()

--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -122,7 +122,7 @@ class PlantDetailFragment : Fragment() {
                 getString(R.string.share_text_plant, plant.name)
             }
         }
-        val shareIntent = ShareCompat.IntentBuilder.from(activity)
+        val shareIntent = ShareCompat.IntentBuilder.from(requireActivity())
             .setText(shareText)
             .setType("text/plain")
             .createChooserIntent()

--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -123,7 +123,7 @@ class PlantDetailFragment : Fragment() {
     // Should be used when user presses a share button/menu item.
     @Suppress("DEPRECATION")
     private fun createShareIntent() {
-        //AS два предложения как укоротить с Kotlin elvis:
+        //AS two sentences how to shorten с Kotlin elvis:
         //val shareText = getString(R.string.share_text_plant, plantDetailViewModel.plant.value)
         //val shareText = plantDetailViewModel.plant.value?.let { plant ->
         //     getString(R.string.share_text_plant, plant.name) }?:""

--- a/app/src/main/java/com/google/samples/apps/sunflower/data/GardenPlantingDao.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/GardenPlantingDao.kt
@@ -47,4 +47,12 @@ interface GardenPlantingDao {
 
     @Delete
     suspend fun deleteGardenPlanting(gardenPlanting: GardenPlanting)
+
+    // AS (must be added to tests)
+    @Query("SELECT * FROM garden_plantings WHERE plant_id = :plantId")
+    suspend fun getGardenPlanting(plantId: String): GardenPlanting
+
+    // AS (must be added to tests)
+    @Query("DELETE FROM garden_plantings")
+    suspend fun clearGarden()
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/data/GardenPlantingRepository.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/GardenPlantingRepository.kt
@@ -29,6 +29,12 @@ class GardenPlantingRepository private constructor(
         gardenPlantingDao.deleteGardenPlanting(gardenPlanting)
     }
 
+    // AS (must be added to tests)
+    suspend fun getGardenPlanting(plantId: String): GardenPlanting = gardenPlantingDao.getGardenPlanting(plantId)
+
+    // AS (must be added to tests)
+    suspend fun clearGarden() = gardenPlantingDao.clearGarden()
+
     fun isPlanted(plantId: String) =
             gardenPlantingDao.isPlanted(plantId)
 

--- a/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/GardenPlantingListViewModel.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/GardenPlantingListViewModel.kt
@@ -18,12 +18,20 @@ package com.google.samples.apps.sunflower.viewmodels
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.google.samples.apps.sunflower.data.GardenPlantingRepository
 import com.google.samples.apps.sunflower.data.PlantAndGardenPlantings
+import kotlinx.coroutines.launch
 
 class GardenPlantingListViewModel internal constructor(
-    gardenPlantingRepository: GardenPlantingRepository
+    val gardenPlantingRepository: GardenPlantingRepository
 ) : ViewModel() {
     val plantAndGardenPlantings: LiveData<List<PlantAndGardenPlantings>> =
             gardenPlantingRepository.getPlantedGardens()
+    // AS
+    fun clearGarden(){
+        viewModelScope.launch {
+            gardenPlantingRepository.clearGarden()
+        }
+    }
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModel.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModel.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.launch
  * The ViewModel used in [PlantDetailFragment].
  */
 class PlantDetailViewModel(
-    plantRepository: PlantRepository,
+    val plantRepository: PlantRepository,
     private val gardenPlantingRepository: GardenPlantingRepository,
     private val plantId: String
 ) : ViewModel() {
@@ -35,9 +35,17 @@ class PlantDetailViewModel(
     val isPlanted = gardenPlantingRepository.isPlanted(plantId)
     val plant = plantRepository.getPlant(plantId)
 
-    fun addPlantToGarden() {
-        viewModelScope.launch {
-            gardenPlantingRepository.createGardenPlanting(plantId)
-        }
+    //AS addPlantToGarden => doAddDeletePlantToGarden for fab +/-
+    var isAddDelete: Boolean = false
+    fun doAddDeletePlantToGarden() {
+        if (!isAddDelete)
+            viewModelScope.launch {
+                gardenPlantingRepository.createGardenPlanting(plantId)
+            }
+        else
+            viewModelScope.launch {
+                val gardenPlanting = gardenPlantingRepository.getGardenPlanting(plantId)
+                gardenPlantingRepository.removeGardenPlanting(gardenPlanting)
+            }
     }
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/views/MaskedCardView.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/views/MaskedCardView.kt
@@ -39,7 +39,7 @@ class MaskedCardView @JvmOverloads constructor(
     @SuppressLint("RestrictedApi")
     private val pathProvider = ShapeAppearancePathProvider()
     private val path: Path = Path()
-    private val shapeAppearance: ShapeAppearanceModel = ShapeAppearanceModel(
+    private val shapeAppearance: ShapeAppearanceModel.Builder = ShapeAppearanceModel.builder(
         context,
         attrs,
         defStyle,
@@ -56,7 +56,7 @@ class MaskedCardView @JvmOverloads constructor(
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         rectF.right = w.toFloat()
         rectF.bottom = h.toFloat()
-        pathProvider.calculatePath(shapeAppearance, 1f, rectF, path)
+        pathProvider.calculatePath(shapeAppearance.build(), 1f, rectF, path)
         super.onSizeChanged(w, h, oldw, oldh)
     }
 }

--- a/app/src/main/res/drawable/ic_minus.xml
+++ b/app/src/main/res/drawable/ic_minus.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright 2020 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!--android:tint="?attr/colorControlNormal"-->
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M7,11v2h10v-2L7,11zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_plant_detail.xml
+++ b/app/src/main/res/layout/fragment_plant_detail.xml
@@ -23,9 +23,6 @@
         <variable
             name="viewModel"
             type="com.google.samples.apps.sunflower.viewmodels.PlantDetailViewModel" />
-        <variable
-            name="callback"
-            type="com.google.samples.apps.sunflower.PlantDetailFragment.Callback" />
     </data>
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -166,10 +163,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/fab_margin"
-            android:onClick="@{() -> callback.add(viewModel.plant)}"
+            android:onClick="@{() -> viewModel.doAddDeletePlantToGarden()}"
             android:tint="@android:color/white"
             app:shapeAppearance="@style/ShapeAppearance.Sunflower.FAB"
-            app:isGone="@{viewModel.isPlanted}"
+            android:visibility="visible"
             app:layout_anchor="@id/appbar"
             app:layout_anchorGravity="bottom|end"
             app:srcCompat="@drawable/ic_plus" />

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -43,5 +43,7 @@
 
     <!-- Accessibility -->
     <string name="a11y_plant_item_image">Imatge de la planta</string>
+    <string name="deleted_plant_from_garden">Deleted plant from garden</string>
+    <string name="garden_cleared">Garden Cleared</string>
 
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -43,5 +43,7 @@
 
     <!-- Accessibility -->
     <string name="a11y_plant_item_image">Bild der Pflanze</string>
+    <string name="deleted_plant_from_garden">Deleted plant from garden</string>
+    <string name="garden_cleared">Garden Cleared</string>
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -43,5 +43,7 @@
 
     <!-- Accessibility -->
     <string name="a11y_plant_item_image">Imagen de la planta</string>
+    <string name="deleted_plant_from_garden">Deleted plant from garden</string>
+    <string name="garden_cleared">Garden Cleared</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -43,5 +43,7 @@
 
     <!-- Accessibility -->
     <string name="a11y_plant_item_image">Image de plante</string>
+    <string name="deleted_plant_from_garden">Deleted plant from garden</string>
+    <string name="garden_cleared">Garden Cleared</string>
 
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -43,5 +43,7 @@
 
     <!-- Accessibility -->
     <string name="a11y_plant_item_image">Immagine della pianta</string>
+    <string name="deleted_plant_from_garden">Deleted plant from garden</string>
+    <string name="garden_cleared">Garden Cleared</string>
 
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -42,5 +42,7 @@
 
     <!-- Accessibility -->
     <string name="a11y_plant_item_image">植物の写真</string>
+    <string name="deleted_plant_from_garden">Deleted plant from garden</string>
+    <string name="garden_cleared">Garden Cleared</string>
 
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -47,5 +47,7 @@
 
     <!-- Accessibility -->
     <string name="a11y_plant_item_image">Изображение растения</string>
+    <string name="deleted_plant_from_garden">Растение вырвано с корнем</string>
+    <string name="garden_cleared">Садик перекопан</string>
 
 </resources>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -43,5 +43,7 @@
 
     <!-- Accessibility -->
     <string name="a11y_plant_item_image">Bitkinin görüntüsü</string>
+    <string name="deleted_plant_from_garden">Deleted plant from garden</string>
+    <string name="garden_cleared">Garden Cleared</string>
 
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -42,5 +42,7 @@
 
     <!-- Accessibility -->
     <string name="a11y_plant_item_image">植物图片</string>
+    <string name="deleted_plant_from_garden">Deleted plant from garden</string>
+    <string name="garden_cleared">Garden Cleared</string>
 
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -42,5 +42,7 @@
 
     <!-- Accessibility -->
     <string name="a11y_plant_item_image">植物圖片</string>
+    <string name="deleted_plant_from_garden">Deleted plant from garden</string>
+    <string name="garden_cleared">Garden Cleared</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
     <string name="plant_details_title" translation_description="Title for the plant details screen where the user can see the details for a specific plant.">Plant details</string>
     <string name="add_plant" translation_description="Button text that prompts user to navigate to the Plant List to add plants to their empty garden.">Add plant</string>
     <string name="added_plant_to_garden" translation_description="Confirmation text that is shown when a user adds a plant to their empty garden.">Added plant to garden</string>
+    <string name="deleted_plant_from_garden" translation_description="Confirmation text that is shown when a user delete a plant to their garden.">Deleted plant from garden</string>
+    <string name="garden_cleared" translation_description="Confirmation text that is shown when a user clear their garden from all plants to.empty ">Garden Cleared</string>
     <string name="garden_empty" translation_description="Text that is shown on the 'My Garden' screen when no plants have been added to the user's garden">Your garden is empty</string>
     <string name="plant_date_header" translation_description="Text that is shown on each plant on the 'My Garden' screen which says the word Planted to show date of planting below">Planted</string>
     <string name="watered_date_header" translation_description="Text that is shown on each plant on the 'My Garden' screen which says the word Last Watered to show date of last watering below">Last Watered</string>

--- a/build.gradle
+++ b/build.gradle
@@ -18,35 +18,36 @@ buildscript {
     // Define versions in a single place
     ext {
         // Sdk and tools
-        compileSdkVersion = 28
+        compileSdkVersion = 29
         minSdkVersion = 21
-        targetSdkVersion = 28
+        targetSdkVersion = 29
+        buildToolsVersion = '29.0.3'
 
         // App dependencies
         appCompatVersion = '1.1.0'
-        constraintLayoutVersion = '2.0.0-beta3'
-        coreTestingVersion = '2.0.0'
-        coroutinesVersion = "1.3.0-M2"
-        espressoVersion = '3.1.1'
-        fragmentVersion = '1.1.0-alpha09'
-        glideVersion = '4.10.0'
+        constraintLayoutVersion = '2.0.0-beta6'
+        coreTestingVersion = '2.1.0'
+        coroutinesVersion = "1.3.6"
+        espressoVersion = '3.2.0'
+        fragmentVersion = '1.3.0-alpha05'
+        glideVersion = '4.11.0'
         gradleVersion = '4.0.0'
-        gsonVersion = '2.8.2'
-        junitVersion = '4.12'
+        gsonVersion = '2.8.6'
+        junitVersion = '4.13'
         kotlinVersion = '1.3.72'
         ktlintVersion = '0.33.0'
-        ktxVersion = '1.0.2'
-        lifecycleVersion = '2.2.0-alpha01'
-        materialVersion = '1.1.0-alpha09'
-        navigationVersion = '2.2.0'
-        recyclerViewVersion = '1.1.0-alpha05'
-        roomVersion = '2.1.0'
+        ktxVersion = '1.3.0'
+        lifecycleVersion = '2.2.0'
+        materialVersion = '1.2.0-beta01'
+        navigationVersion = '2.2.2'
+        recyclerViewVersion = '1.2.0-alpha03'
+        roomVersion = '2.2.5'
         runnerVersion = '1.0.1'
-        truthVersion = '0.42'
-        testExtJunit = '1.1.0'
+        truthVersion = '1.0.1'
+        testExtJunit = '1.1.1'
         uiAutomatorVersion = '2.2.0'
         viewPagerVersion = '1.0.0'
-        workVersion = '2.1.0'
+        workVersion = '2.3.4'
     }
 
     repositories {
@@ -55,7 +56,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:$gradleVersion"
+        classpath "com.android.tools.build:gradle:${gradleVersion}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$navigationVersion"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu May 28 10:37:52 PDT 2020
+#Tue Jun 02 19:14:18 MSK 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip


### PR DESCRIPTION
Improvement: clear garden end delete plant
1. Added the ability to clear the entire "My garden" tap on the filter icon
2. Added the ability to delete each plant from "My garden" by tap on fab "-"
3. Changed the fab UI, by tap on fab " + "changes to" - " and back.
4. Deprecated java constructs are replaced with the corresponding JetPack

Not done:
1. Translation of two messages into N-2 languages (English in other languages)
2. Not added to tests