### PR TITLE
Upgraded Spotless plugin to declare outputs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ buildscript {
 }
 
 plugins {
-    id "com.diffplug.gradle.spotless" version "3.24.0"
+    id "com.diffplug.gradle.spotless" version "4.3.0"
 }
 
 allprojects {


### PR DESCRIPTION
Upgraded com.diffplug.gradle.spotless to version 4.3.0 to declare outputs to incremental task.

Previous version was 3.24.0. When building, it produced the following exception:

```bash
$ ./gradlew build

> Configure project :app

> Task :spotlessKotlin FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':spotlessKotlin'.
> You must declare outputs or use `TaskOutputs.upToDateWhen()` when using the incremental task API
```

This issue was fixed in Spotless 3.24.2 as per [Issue #427](https://github.com/diffplug/spotless/issues/427). I optimistically upgraded to the latest release (4.3.0, June 2020). There are also higher minor releases (3.30.0, May 2020) and patch releases (3.24.3, Sep 2019) available in [mvnrepository](https://mvnrepository.com/artifact/com.diffplug.spotless/spotless-plugin-gradle) as alternatives. The build passes on all three.