### PR TITLE
fix formatting so it passes ktlint (configured with -a option) at com…

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/api/UnsplashService.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/api/UnsplashService.kt
@@ -37,7 +37,7 @@ interface UnsplashService {
         @Query("page") page: Int,
         @Query("per_page") perPage: Int,
         @Query("client_id") clientId: String = BuildConfig.UNSPLASH_ACCESS_KEY
-    ) : UnsplashSearchResponse
+    ): UnsplashSearchResponse
 
     companion object {
         private const val BASE_URL = "https://api.unsplash.com/"

--- a/app/src/main/java/com/google/samples/apps/sunflower/data/UnsplashPagingSource.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/UnsplashPagingSource.kt
@@ -21,7 +21,7 @@ import com.google.samples.apps.sunflower.api.UnsplashService
 
 private const val UNSPLASH_STARTING_PAGE_INDEX = 1
 
-class UnsplashPagingSource (
+class UnsplashPagingSource(
     private val service: UnsplashService,
     private val query: String
 ) : PagingSource<Int, UnsplashPhoto>() {

--- a/app/src/main/java/com/google/samples/apps/sunflower/data/UnsplashPhotoUrls.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/UnsplashPhotoUrls.kt
@@ -25,6 +25,6 @@ import com.google.gson.annotations.SerializedName
  * For more details, consult the API documentation
  * [here](https://unsplash.com/documentation#example-image-use).
  */
-data class UnsplashPhotoUrls (
+data class UnsplashPhotoUrls(
     @field:SerializedName("small") val small: String
 )

--- a/app/src/main/java/com/google/samples/apps/sunflower/data/UnsplashRepository.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/UnsplashRepository.kt
@@ -22,7 +22,7 @@ import androidx.paging.PagingData
 import com.google.samples.apps.sunflower.api.UnsplashService
 import kotlinx.coroutines.flow.Flow
 
-class UnsplashRepository (private val service: UnsplashService) {
+class UnsplashRepository(private val service: UnsplashService) {
 
     fun getSearchResultStream(query: String): Flow<PagingData<UnsplashPhoto>> {
         return Pager(

--- a/app/src/main/java/com/google/samples/apps/sunflower/data/UnsplashUser.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/UnsplashUser.kt
@@ -25,7 +25,7 @@ import com.google.gson.annotations.SerializedName
  * project are listed below. For a full list of fields, consult the API documentation
  * [here](https://unsplash.com/documentation#get-a-users-public-profile).
  */
-data class UnsplashUser (
+data class UnsplashUser(
     @field:SerializedName("name") val name: String,
     @field:SerializedName("username") val username: String
 ) {

--- a/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/GalleryViewModelFactory.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/GalleryViewModelFactory.kt
@@ -20,7 +20,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.google.samples.apps.sunflower.data.UnsplashRepository
 
-class GalleryViewModelFactory (
+class GalleryViewModelFactory(
     private val unsplashRepository: UnsplashRepository
 ) : ViewModelProvider.Factory {
 


### PR DESCRIPTION
…mand line. Code formatting is a simple thing, but when someone new to the project gets a failed build on a clean copy of the repo it does not inspire confidence ;-)


background:  on MacOS, I installed ktlint (using brew), configured with -a (kotlin android style) option, run ./gradlew build, and build fails on several formatting problems. I changed the code so build succeeds, required changes (and nothing else) are in this PR