### PR TITLE
Remove kotlin stdlib dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,7 +82,6 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:$rootProject.okhttpLoggingVersion"
     implementation "com.squareup.retrofit2:converter-gson:$rootProject.retrofitVersion"
     implementation "com.squareup.retrofit2:retrofit:$rootProject.retrofitVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$rootProject.kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$rootProject.coroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$rootProject.coroutinesVersion"
 


### PR DESCRIPTION
The stdlib library – starting from Kotlin 1.4.0, the stdlib dependency is added automatically.

### [Dependency on the standard library added by default](https://kotlinlang.org/docs/reference/whatsnew14.html#dependency-on-the-standard-library-added-by-default)
You no longer need to declare a dependency on the stdlib library in any Kotlin Gradle project, including a multiplatform one. The dependency is added by default.

### Difference
- [x] Removed a kotlin stdlib dependency in the `app` module.