### PR TITLE
Fixed title in the Toolbar is not in the center in horizontal #656

### DIFF
--- a/app/src/main/res/layout/fragment_view_pager.xml
+++ b/app/src/main/res/layout/fragment_view_pager.xml
@@ -54,6 +54,7 @@
                     style="@style/Widget.MaterialComponents.Toolbar.Primary"
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
+                    app:contentInsetStart="0dp"
                     app:layout_collapseMode="parallax">
 
                 <TextView


### PR DESCRIPTION
### Description
Issue link: https://github.com/android/sunflower/issues/656

### Overview
Before changes:
![Screenshot 2020-10-02 at 14 36 59](https://user-images.githubusercontent.com/18151158/94932445-feccd200-04c0-11eb-868e-27af26bbaa64.png)

After changes:
![Screenshot 2020-10-02 at 14 57 58](https://user-images.githubusercontent.com/18151158/94932438-fc6a7800-04c0-11eb-9ccd-00e34735ef53.png)
