### PR TITLE
Fix Memory Leaks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,6 +96,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$rootProject.coroutinesVersion"
     implementation "com.google.dagger:hilt-android:$rootProject.hiltVersion"
     implementation "androidx.hilt:hilt-lifecycle-viewmodel:$rootProject.hiltViewModelVersion"
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:$rootProject.leakCanaryVersion"
 
     // Testing dependencies
     kaptAndroidTest "com.google.dagger:hilt-android-compiler:$rootProject.hiltVersion"

--- a/app/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
@@ -32,8 +32,6 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class GardenFragment : Fragment() {
 
-    private lateinit var binding: FragmentGardenBinding
-
     private val viewModel: GardenPlantingListViewModel by viewModels()
 
     override fun onCreateView(
@@ -41,7 +39,7 @@ class GardenFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentGardenBinding.inflate(inflater, container, false)
+        val binding = FragmentGardenBinding.inflate(inflater, container, false)
         val adapter = GardenPlantingAdapter()
         binding.gardenList.adapter = adapter
 

--- a/app/src/main/java/com/google/samples/apps/sunflower/HomeViewPagerFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/HomeViewPagerFragment.kt
@@ -41,7 +41,7 @@ class HomeViewPagerFragment : Fragment() {
         val tabLayout = binding.tabs
         val viewPager = binding.viewPager
 
-        viewPager.adapter = SunflowerPagerAdapter(this)
+        viewPager.adapter = SunflowerPagerAdapter(childFragmentManager, viewLifecycleOwner.lifecycle)
 
         // Set the icon and text for each tab
         TabLayoutMediator(tabLayout, viewPager) { tab, position ->

--- a/app/src/main/java/com/google/samples/apps/sunflower/HomeViewPagerFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/HomeViewPagerFragment.kt
@@ -69,4 +69,9 @@ class HomeViewPagerFragment : Fragment() {
             else -> null
         }
     }
+
+    override fun onDestroyView() {
+        (activity as AppCompatActivity).setSupportActionBar(null)
+        super.onDestroyView()
+    }
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/adapters/SunflowerPagerAdapter.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/adapters/SunflowerPagerAdapter.kt
@@ -17,6 +17,8 @@
 package com.google.samples.apps.sunflower.adapters
 
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.google.samples.apps.sunflower.GardenFragment
 import com.google.samples.apps.sunflower.PlantListFragment
@@ -24,7 +26,10 @@ import com.google.samples.apps.sunflower.PlantListFragment
 const val MY_GARDEN_PAGE_INDEX = 0
 const val PLANT_LIST_PAGE_INDEX = 1
 
-class SunflowerPagerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {
+class SunflowerPagerAdapter(
+    fragmentManager: FragmentManager,
+    lifecycle: Lifecycle
+) : FragmentStateAdapter(fragmentManager, lifecycle) {
 
     /**
      * Mapping of the ViewPager page indexes to their respective Fragments

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ buildscript {
         kotlinVersion = '1.4.0'
         ktlintVersion = '0.38.1'
         ktxVersion = '1.0.2'
+        leakCanaryVersion = '2.4'
         lifecycleVersion = '2.2.0'
         materialVersion = '1.2.0'
         navigationVersion = '2.2.0'


### PR DESCRIPTION
## Specs

**Hardware Support**
- Device: Pixel 4 XL
- API Level: 28 / Pie
- RAM: 2048 MB
- VM heap: 2048 MB

**Library Support**
- LeakCanary: 2.4

## Detected Issues

1. Retained `GardenFragment`'s `mRoot` since it's still being referenced by the `binding` instance after `onDestroyView`.
[Leak Trace](https://docs.google.com/document/d/1w2hC6WfY9Z185AV_tIIaPncdSB3noxBhaGXEt8O1a8A/edit?usp=sharing)
[Heap Dump File](https://drive.google.com/file/d/1V9zmhuOpOizGHh4FS5D3kssaMudcdGzF/view?usp=sharing)

2. Retained `HomeViewPagerFragment`'s `toolbar` since it's still being referenced by parent `GardenActivity` after `onDestroyView`.
[Leak Trace](https://docs.google.com/document/d/1AEsRyC3Ay28Wx5ILqHuhtteVs9NDTIughX31CtPwvxc/edit?usp=sharing)
[Heap Dump File](https://drive.google.com/file/d/1Vg9XVFidDY5NSAxBRVeL15vsD8SbBWcN/view?usp=sharing)

3. Retained `HomeViewPagerFragment`'s `viewPager` instance since it's is still being referenced by `FragmentStateAdapter` after **detach**.
[Leak Trace](https://docs.google.com/document/d/1UVZMt1WXwHuBgIg1MAXOfPt76iXv4hE0WYxXrxcvtfU/edit?usp=sharing)
[Heap Dump File](https://drive.google.com/file/d/1gLgDlq3U0U_TDN0X1cCTyd4nHX3ol78n/view?usp=sharing)

## Fixes

1. It is not quite necessary to declare `binding` as a field (at least for current `GardenFragment` design). Declaring it at local level will suffice.
**Note**: When at some point `binding` is required to be put as a field, we need to declare it as nullable in order to nullify it back when `onDestroyView`. Or we could remove the _nullification_ boilerplate by abstracting them with delegated property fashion, [for instance](https://proandroiddev.com/make-android-view-binding-great-with-kotlin-b71dd9c87719).

2. Remove the reference to `toolbar` when `onDestroyView`.

3. Known issue as listed on:
https://issuetracker.google.com/issues/151212195,
https://issuetracker.google.com/issues/154751401,
Workaround is to pass `FragmentViewLifecycleOwner`'s `Lifecycle` as argument in `FragmentStateAdapter` instantiation.



# Todo
- [ ] Remove lib LeakCanary after maintainers approve this PR (or should we?).