### PR TITLE
Rename view name in fragment_view_pager.xml

### DIFF
--- a/app/src/main/res/layout/fragment_plant_detail.xml
+++ b/app/src/main/res/layout/fragment_plant_detail.xml
@@ -70,7 +70,7 @@
                     app:imageFromUrl="@{viewModel.plant.imageUrl}"
                     app:layout_collapseMode="parallax" />
 
-                <androidx.appcompat.widget.Toolbar
+                <com.google.android.material.appbar.MaterialToolbar
                     android:id="@+id/toolbar"
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/fragment_view_pager.xml
+++ b/app/src/main/res/layout/fragment_view_pager.xml
@@ -49,7 +49,7 @@
                 app:layout_scrollFlags="scroll|snap"
                 app:toolbarId="@id/toolbar">
 
-                <androidx.appcompat.widget.Toolbar
+                <com.google.android.material.appbar.MaterialToolbar
                     android:id="@+id/toolbar"
                     style="@style/Widget.MaterialComponents.Toolbar.Primary"
                     android:layout_width="match_parent"
@@ -64,7 +64,7 @@
                     android:text="@string/app_name"
                     android:textAppearance="?attr/textAppearanceHeadline5" />
 
-                </androidx.appcompat.widget.Toolbar>
+                </com.google.android.material.appbar.MaterialToolbar>
 
             </com.google.android.material.appbar.CollapsingToolbarLayout>
 


### PR DESCRIPTION
##  What fix?

Renamed view name in fragment_view_pager from `<androidx.appcompat.widget.Toolbar>` to `<com.google.android.material.appbar.MaterialToolbar>`

## Why fix?

I think It seems that the existing toolbar is the one of Material Design.
According to [Material Design Guide - app bars top documentation](https://material.io/develop/android/components/app-bars-top), It is using `<com.google.android.material.appbar.MaterialToolbar>` instead of `<androidx.appcompat.widget.Toolbar>`.
And, [MaterialToolbar documentation](https://developer.android.com/reference/com/google/android/material/appbar/MaterialToolbar) also announces this.

So I tried to change. Please review. Thank you😊

