### PR TITLE
Refactor Codes : Use onViewCreated()

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/HomeViewPagerFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/HomeViewPagerFragment.kt
@@ -22,12 +22,14 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import com.google.samples.apps.sunflower.adapters.MY_GARDEN_PAGE_INDEX
 import com.google.samples.apps.sunflower.adapters.PLANT_LIST_PAGE_INDEX
 import com.google.samples.apps.sunflower.adapters.SunflowerPagerAdapter
 import com.google.samples.apps.sunflower.databinding.FragmentViewPagerBinding
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.android.synthetic.main.fragment_view_pager.view.*
 
 @AndroidEntryPoint
 class HomeViewPagerFragment : Fragment() {
@@ -38,8 +40,14 @@ class HomeViewPagerFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         val binding = FragmentViewPagerBinding.inflate(inflater, container, false)
-        val tabLayout = binding.tabs
-        val viewPager = binding.viewPager
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val tabLayout = view.tabs
+        val viewPager = view.view_pager
 
         viewPager.adapter = SunflowerPagerAdapter(this)
 
@@ -49,9 +57,7 @@ class HomeViewPagerFragment : Fragment() {
             tab.text = getTabTitle(position)
         }.attach()
 
-        (activity as AppCompatActivity).setSupportActionBar(binding.toolbar)
-
-        return binding.root
+        (activity as AppCompatActivity).setSupportActionBar(view.toolbar)
     }
 
     private fun getTabIcon(position: Int): Int {


### PR DESCRIPTION
## What changed?

* file name : HomeViewPagerFragment.kt
* Use onViewCreated() for initialization and other tasks.

## Why changed?

* I learned about the Fragment Life Cycle.
* onCreateView() is for having the fragment instantiate. and returns the instantiated view to onViewCreated().
* I think separating onCreateView() and onViewCreated() is more suitable for the meaning of the Fragment life cycle.
* What do you think of this?

I am not good at English, but thank you for reading.😃