### PR TITLE
chore: remove deprecated kotlin-android-extensions plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,6 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
 apply plugin: 'androidx.navigation.safeargs.kotlin'


### PR DESCRIPTION
Not only is the kotlin-android-extensions deprecated, but it's also not being used in this project.