### PR TITLE
Gradle build: switching from 'jcenter()' to 'mavenCentral()'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -73,7 +73,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
**Details / rationale:**
- JCenter repository sunset is announced for a May 1st 2021
- `'com.android.tools.build:gradle'` plugin version is bumped: 4.1.1 -->> 4.1.2

**Related links:**
- https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter
- https://www.infoq.com/news/2021/02/jfrog-jcenter-bintray-closure
- https://blog.sonatype.com/dear-bintray-and-jcenter-users-heres-what-you-need-to-know-about-the-central-repository