### PR TITLE
Move logic to ViewModel so it can be unit-tested

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
@@ -59,7 +59,7 @@ class PlantListFragment : Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.filter_zone -> {
-                updateData()
+                viewModel.updatePlantFilter(growZoneNumber = 9)
                 true
             }
             else -> super.onOptionsItemSelected(item)
@@ -69,16 +69,6 @@ class PlantListFragment : Fragment() {
     private fun subscribeUi(adapter: PlantAdapter) {
         viewModel.plants.observe(viewLifecycleOwner) { plants ->
             adapter.submitList(plants)
-        }
-    }
-
-    private fun updateData() {
-        with(viewModel) {
-            if (isFiltered()) {
-                clearGrowZoneNumber()
-            } else {
-                setGrowZoneNumber(9)
-            }
         }
     }
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantListViewModel.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantListViewModel.kt
@@ -88,15 +88,23 @@ class PlantListViewModel @Inject internal constructor(
         }
     }
 
-    fun setGrowZoneNumber(num: Int) {
+    fun updatePlantFilter(growZoneNumber: Int) {
+        if (isFiltered()) {
+            clearGrowZoneNumber()
+        } else {
+            setGrowZoneNumber(growZoneNumber)
+        }
+    }
+
+    private fun setGrowZoneNumber(num: Int) {
         growZone.value = num
     }
 
-    fun clearGrowZoneNumber() {
+    private fun clearGrowZoneNumber() {
         growZone.value = NO_GROW_ZONE
     }
 
-    fun isFiltered() = growZone.value != NO_GROW_ZONE
+    private fun isFiltered() = growZone.value != NO_GROW_ZONE
 
     companion object {
         private const val NO_GROW_ZONE = -1


### PR DESCRIPTION
From a test-driven perspective it would be beneficial to get most of the logic covered in small unit tests since this is the fastest and most reliable way of testing an Android application. I believe a ViewModel can be unit-tested whereas a Fragment cannot, without heavy mocking.