### PR TITLE
FIXED:Some plant titles do not appear on title bar due to limited scroll

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -46,6 +46,6 @@
     <dimen name="gallery_header_margin">72dp</dimen>
 
     <!-- minimum height of plant detail page so that the collapsing toolbar can be shown on every page -->
-    <dimen name="plant_description_min_height">555dp</dimen>
+    <dimen name="plant_description_min_height">655dp</dimen>
 
 </resources>


### PR DESCRIPTION
I have fixed the scroll bar issue on Pixel 3X emulator .
Attaching Screen shot
![sunflower](https://user-images.githubusercontent.com/32665518/125184392-e56c6980-e23a-11eb-9c1b-e0cf6ba96b61.png)
