### PR TITLE
Update deprecated testing

### DIFF
--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/GardenActivityTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/GardenActivityTest.kt
@@ -21,7 +21,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.rule.ActivityTestRule
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Rule
@@ -32,10 +32,10 @@ import org.junit.rules.RuleChain
 class GardenActivityTest {
 
     private val hiltRule = HiltAndroidRule(this)
-    private val activityTestRule = ActivityTestRule(GardenActivity::class.java)
+    private val activityTestRule = ActivityScenarioRule(GardenActivity::class.java)
 
     @get:Rule
-    val rule = RuleChain
+    val rule: RuleChain = RuleChain
         .outerRule(hiltRule)
         .around(activityTestRule)
 

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/MainCoroutineRule.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/MainCoroutineRule.kt
@@ -17,30 +17,21 @@
 package com.google.samples.apps.sunflower
 
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.*
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
 class MainCoroutineRule(
-    val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
 ) : TestWatcher() {
 
-    override fun starting(description: Description?) {
+    override fun starting(description: Description) {
         super.starting(description)
         Dispatchers.setMain(testDispatcher)
     }
 
-    override fun finished(description: Description?) {
+    override fun finished(description: Description) {
         super.finished(description)
         Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
     }
 }
-
-fun MainCoroutineRule.runBlockingTest(block: suspend () -> Unit) =
-    this.testDispatcher.runBlockingTest {
-        block()
-    }

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/data/PlantDaoTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/data/PlantDaoTest.kt
@@ -22,9 +22,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.After
-import org.junit.Assert.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModelTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModelTest.kt
@@ -48,7 +48,7 @@ class PlantDetailViewModelTest {
     private val coroutineRule = MainCoroutineRule()
 
     @get:Rule
-    val rule = RuleChain
+    val rule: RuleChain = RuleChain
             .outerRule(hiltRule)
             .around(instantTaskExecutorRule)
             .around(coroutineRule)

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModelTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModelTest.kt
@@ -24,11 +24,11 @@ import com.google.samples.apps.sunflower.MainCoroutineRule
 import com.google.samples.apps.sunflower.data.AppDatabase
 import com.google.samples.apps.sunflower.data.GardenPlantingRepository
 import com.google.samples.apps.sunflower.data.PlantRepository
-import com.google.samples.apps.sunflower.runBlockingTest
 import com.google.samples.apps.sunflower.utilities.getValue
 import com.google.samples.apps.sunflower.utilities.testPlant
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Before
@@ -36,7 +36,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import javax.inject.Inject
-import kotlin.jvm.Throws
 
 @HiltAndroidTest
 class PlantDetailViewModelTest {
@@ -80,7 +79,7 @@ class PlantDetailViewModelTest {
     @Suppress("BlockingMethodInNonBlockingContext")
     @Test
     @Throws(InterruptedException::class)
-    fun testDefaultValues() = coroutineRule.runBlockingTest {
+    fun testDefaultValues() = runTest {
         assertFalse(getValue(viewModel.isPlanted))
     }
 }

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/worker/SeedDatabaseWorkerTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/worker/SeedDatabaseWorkerTest.kt
@@ -18,7 +18,6 @@ package com.google.samples.apps.sunflower.worker
 
 import android.content.Context
 import android.util.Log
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.work.Configuration
 import androidx.work.ListenableWorker.Result
@@ -30,7 +29,7 @@ import androidx.work.workDataOf
 import com.google.samples.apps.sunflower.utilities.PLANT_DATA_FILENAME
 import com.google.samples.apps.sunflower.workers.SeedDatabaseWorker
 import org.hamcrest.CoreMatchers.`is`
-import org.junit.Assert.assertThat
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/com/google/samples/apps/sunflower/data/GardenPlantingTest.kt
+++ b/app/src/test/java/com/google/samples/apps/sunflower/data/GardenPlantingTest.kt
@@ -17,8 +17,8 @@
 package com.google.samples.apps.sunflower.data
 
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThat
 import org.junit.Test
 import java.util.Calendar
 import java.util.Calendar.DAY_OF_MONTH


### PR DESCRIPTION
- replace junit `assertThat` with hamcrest one
- replace `ActivityTestRule` with `ActivityScenarioRule`
- replace `TestCoroutineDispatcher` with `TestDispatcher`

Note: if the test can not be run at all, downgrade **espresso** to 3.3.0 as i mentioned [here](https://github.com/android/sunflower/issues/764).