### PR TITLE
Removed redundant let call

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
@@ -53,9 +53,7 @@ class PlantAdapter : ListAdapter<Plant, RecyclerView.ViewHolder>(PlantDiffCallba
     ) : RecyclerView.ViewHolder(binding.root) {
         init {
             binding.setClickListener {
-                binding.plant?.let { plant ->
-                    navigateToPlant(plant, it)
-                }
+                navigateToPlant(binding.plant, it)
             }
         }
 


### PR DESCRIPTION
Removed redundant call to let at

``binding.setClickListener {
                binding.plant?.let { plant ->
                    navigateToPlant(plant, it)
                }
            }``