### PR TITLE
Correct PlantDetailViewModelTest testing by Espresso dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,9 +23,6 @@ apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildFeatures {
-        dataBinding true
-    }
     defaultConfig {
         applicationId "com.google.samples.apps.sunflower"
         minSdkVersion rootProject.minSdkVersion
@@ -130,7 +127,9 @@ dependencies {
     // Testing dependencies
     kaptAndroidTest "com.google.dagger:hilt-android-compiler:$rootProject.hiltVersion"
     androidTestImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"
-    androidTestImplementation "androidx.test.espresso:espresso-contrib:$rootProject.espressoVersion"
+    androidTestImplementation ("androidx.test.espresso:espresso-contrib:$rootProject.espressoVersion"){
+        exclude group: 'org.checkerframework', module: 'checker'
+    }
     androidTestImplementation "androidx.test.espresso:espresso-core:$rootProject.espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-intents:$rootProject.espressoVersion"
     androidTestImplementation "androidx.test.ext:junit:$rootProject.testExtJunit"

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,9 @@ buildscript {
     // Define versions in a single place
     ext {
         // Sdk and tools
-        compileSdkVersion = 31
+        compileSdkVersion = 33
         minSdkVersion = 21
-        targetSdkVersion = 31
+        targetSdkVersion = 33
 
          // App dependencies
         activityComposeVersion = '1.3.0-rc02'


### PR DESCRIPTION
The below error is shown on the PlantDetailViewModelTest running.

`FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':app:checkDebugAndroidTestDuplicateClasses'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable
   > Duplicate class org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey found in modules checker-3.1 
     
This is fixed by Gradle changing.
Also, remove a duplicate data binding and buildFeatures.
