### PR TITLE
Fix the issue instrumented tests can't be executed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,6 +139,7 @@ dependencies {
     androidTestImplementation "com.google.truth:truth:$rootProject.truthVersion"
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$rootProject.composeVersion"
     androidTestImplementation "com.google.dagger:hilt-android-testing:$rootProject.hiltVersion"
+    androidTestImplementation "com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:$rootProject.accessibilityTestFrameworkVersion"
     androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$rootProject.coroutinesVersion"
     testImplementation "junit:junit:$rootProject.junitVersion"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ buildscript {
 
          // App dependencies
         activityComposeVersion = '1.3.0-rc02'
+        accessibilityTestFrameworkVersion = '4.0.0'
         appCompatVersion = '1.4.1'
         benchmarkVersion = '1.1.0-rc02'
         coilVersion = '2.0.0'


### PR DESCRIPTION
Updating the Espresso to 3.4.0 broke the instrumented tests as in
https://github.com/android/android-test/issues/861

This PR explicitly specifies the version of the accessibility-test-framework

Fixes #764 

But #783 still persists even after this fix.