### PR TITLE
Disabling androidTest temporarily

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -43,32 +43,33 @@ jobs:
           name: assemble
           path: assemble.zip
 
-  androidTest:
-    needs: build
-    runs-on: macOS-latest
-    timeout-minutes: 45
-
-    steps:
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-      - uses: actions/checkout@v3
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
-
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Run instrumented tests with GMD
-        run: ./gradlew pixel2api27DebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" -Pandroid.experimental.testOptions.managedDevices.setupTimeoutMinutes=20 -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true --info
-
-      - name: Upload test reports
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-reports
-          path: |
-            '*/build/outputs/androidTest-results/'
-            '!**/*"*' # Couldn't exclude a file with double quotation. Revisit the path once b/242988834 is fixed
+#  Disabling androidTest temporarily due to the stability issue b/251319989
+#  androidTest:
+#    needs: build
+#    runs-on: macOS-latest
+#    timeout-minutes: 45
+#
+#    steps:
+#      - uses: actions/setup-java@v3
+#        with:
+#          distribution: 'temurin'
+#          java-version: '11'
+#      - uses: actions/checkout@v3
+#
+#      - name: Setup Android SDK
+#        uses: android-actions/setup-android@v2
+#
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#
+#      - name: Run instrumented tests with GMD
+#        run: ./gradlew pixel2api27DebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" -Pandroid.experimental.testOptions.managedDevices.setupTimeoutMinutes=20 -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true --info
+#
+#      - name: Upload test reports
+#        if: always()
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: test-reports
+#          path: |
+#            '*/build/outputs/androidTest-results/'
+#            '!**/*"*' # Couldn't exclude a file with double quotation. Revisit the path once b/242988834 is fixed


### PR DESCRIPTION
Due to the stability issue as in b/251319989
Enable it once the issue is fixed.