### PR TITLE
Exclude version files in release mode.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,6 +100,14 @@ android {
   }
 }
 
+androidComponents {
+  onVariants(selector().withBuildType("release")) {
+    // Only exclude *.version files in release mode as debug mode requires
+    // these files for layout inspector to work.
+    it.packaging.resources.excludes.add("META-INF/*.version")
+  }
+}
+
 dependencies {
   kapt(libs.androidx.room.compiler)
   kapt(libs.hilt.android.compiler)


### PR DESCRIPTION
Demonstrate removing META-INF version files in release mode. These version files are required in debug mode for layout inspector to work.
