### PR TITLE
Update home_screen.xml

### DIFF
--- a/app/src/main/res/layout/home_screen.xml
+++ b/app/src/main/res/layout/home_screen.xml
@@ -25,6 +25,7 @@
       android:id="@+id/coordinator_layout"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
+      android:statusBarColor="@color/transparent"
       android:fitsSystemWindows="true">
 
     <androidx.compose.ui.platform.ComposeView
@@ -37,6 +38,8 @@
         android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:windowTranslucentStatus="true"
+        android:windowDrawsSystemBarBackgrounds="false"
         android:fitsSystemWindows="true"
         android:theme="@style/Theme.Sunflower.AppBarOverlay">
 


### PR DESCRIPTION
Positioned the toolbar below the status bar while maintaining the window's translucent status.
[Source 1](https://stackoverflow.com/questions/28807874/android-toolbar-status-bar-overlapping#:~:text=as%20Virus%20correctly%20says%2C%20the%20answer%20is%20here%3A,xml%20item%20and%20it%20will%20work%20fine%20%3A%29), [Source 2](https://stackoverflow.com/questions/29738510/toolbar-overlapping-below-status-bar)

