### PR TITLE
Fix issue #842 second way

### DIFF
--- a/app/src/main/res/layout/home_screen.xml
+++ b/app/src/main/res/layout/home_screen.xml
@@ -25,7 +25,7 @@
       android:id="@+id/coordinator_layout"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:fitsSystemWindows="true">
+      android:paddingTop="@dimen/status_bar_height">
 
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/compose_view"
@@ -37,7 +37,6 @@
         android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true"
         android:theme="@style/Theme.Sunflower.AppBarOverlay">
 
       <com.google.android.material.appbar.CollapsingToolbarLayout

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -50,4 +50,7 @@
     <!-- minimum height of plant detail page so that the collapsing toolbar can be shown on every page -->
     <dimen name="plant_description_min_height">555dp</dimen>
 
+    <!-- height of the plant detail page when the collapsing toolbar is expanded -->
+    <dimen name="status_bar_height">24dp</dimen>
+
 </resources>


### PR DESCRIPTION
issue : #842 
In this PR, I solved the bug that overlaps statusbar and appbar by settinging the padding value.

This way, scroll animation at the bottom of the app bar works, but other bugs could not be fixed.

You can see the PR that fixed other bugs in this link. https://github.com/android/sunflower/pull/848

However, the PR of this link has the disadvantage of not being able to operate the animation of the app bar. 




https://github.com/android/sunflower/assets/93872496/1c2d8abf-fcc6-4cea-8535-1793a8509de4
