### PR TITLE
Handling insets in Compose and not in Views.

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/SunflowerApp.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/SunflowerApp.kt
@@ -20,7 +20,9 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import androidx.appcompat.widget.Toolbar
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.app.ShareCompat
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -64,6 +66,7 @@ fun SunFlowerNavHost(
     NavHost(navController = navController, startDestination = "home") {
         composable("home") {
             HomeScreen(
+                modifier = Modifier.systemBarsPadding(),
                 onPlantClick = {
                     navController.navigate("plantDetail/${it.plantId}")
                 },

--- a/app/src/main/res/layout/home_screen.xml
+++ b/app/src/main/res/layout/home_screen.xml
@@ -24,8 +24,7 @@
   <androidx.coordinatorlayout.widget.CoordinatorLayout
       android:id="@+id/coordinator_layout"
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:fitsSystemWindows="true">
+      android:layout_height="match_parent">
 
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/compose_view"
@@ -37,7 +36,6 @@
         android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true"
         android:theme="@style/Theme.Sunflower.AppBarOverlay">
 
       <com.google.android.material.appbar.CollapsingToolbarLayout


### PR DESCRIPTION
Similar effect to #858 but in this change, I'm adding insets support on the Compose side instead of the Views side.
This follows our guidance where the outermost layout (which in Sunflower is a `ComposeView`) should consume the insets.

Context: https://developer.android.com/jetpack/compose/layouts/insets#interop-view

