### PR TITLE
[Fix #829] Migrate Sunflower to Material 3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,6 +142,7 @@ dependencies {
   implementation(libs.androidx.compose.foundation)
   implementation(libs.androidx.compose.foundation.layout)
   implementation(libs.androidx.compose.material)
+  implementation(libs.androidx.compose.material3)
   implementation(libs.androidx.compose.ui.viewbinding)
   implementation(libs.androidx.compose.ui.tooling.preview)
   implementation(libs.androidx.compose.runtime.livedata)

--- a/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
@@ -32,6 +32,7 @@ import androidx.core.view.WindowCompat
 import com.google.accompanist.themeadapter.material.MdcTheme
 import com.google.samples.apps.sunflower.compose.SunflowerApp
 import com.google.samples.apps.sunflower.compose.home.SunflowerPage
+import com.google.samples.apps.sunflower.compose.theme.SunflowerTheme
 import com.google.samples.apps.sunflower.viewmodels.PlantListViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -61,29 +62,29 @@ class GardenActivity : ComponentActivity() {
 
         // Displaying edge-to-edge
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        setContent {
-            MdcTheme {
-                SunflowerApp(
+
+        setContentView(ComposeView(this).apply {
+            // Provide a different ComposeView instead of using ComponentActivity's setContent
+            // method so that the `consumeWindowInsets` property can be set to `false`. This is
+            // needed so that insets can be properly applied to `HomeScreen` which uses View interop
+            // This can likely be changed when `HomeScreen` is fully in Compose.
+            consumeWindowInsets = false
+            setContent {
+                SunflowerTheme {
+                    SunflowerApp(
                         onPageChange = { page ->
                             when (page) {
                                 SunflowerPage.MY_GARDEN -> removeMenuProvider(menuProvider)
                                 SunflowerPage.PLANT_LIST -> addMenuProvider(
-                                        menuProvider,
-                                        this@GardenActivity
+                                    menuProvider,
+                                    this@GardenActivity
                                 )
                             }
                         },
                         plantListViewModel = viewModel,
-                )
+                    )
+                }
             }
-        }
-
-//        setContentView(ComposeView(this).apply {
-//            // Provide a different ComposeView instead of using ComponentActivity's setContent
-//            // method so that the `consumeWindowInsets` property can be set to `false`. This is
-//            // needed so that insets can be properly applied to `HomeScreen` which uses View interop
-//            // This can likely be changed when `HomeScreen` is fully in Compose.
-//            consumeWindowInsets = false
-//        })
+        })
     }
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
@@ -21,6 +21,7 @@ import android.util.Log
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -36,7 +37,7 @@ import dagger.hilt.android.AndroidEntryPoint
 
 // TODO: update the superclass to ComponentActivity https://github.com/android/sunflower/issues/829
 @AndroidEntryPoint
-class GardenActivity : AppCompatActivity() {
+class GardenActivity : ComponentActivity() {
 
     private val viewModel: PlantListViewModel by viewModels()
 
@@ -72,7 +73,7 @@ class GardenActivity : AppCompatActivity() {
                 MdcTheme {
                     SunflowerApp(
                         onAttached = { toolbar ->
-                            setSupportActionBar(toolbar)
+                          //  setSupportActionBar(toolbar)
                         },
                         onPageChange = { page ->
                             when (page) {

--- a/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
@@ -71,9 +71,6 @@ class GardenActivity : ComponentActivity() {
             setContent {
                 MdcTheme {
                     SunflowerApp(
-                        onAttached = { toolbar ->
-                          //  setSupportActionBar(toolbar)
-                        },
                         onPageChange = { page ->
                             when (page) {
                                 SunflowerPage.MY_GARDEN -> removeMenuProvider(menuProvider)

--- a/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
@@ -61,29 +61,29 @@ class GardenActivity : ComponentActivity() {
 
         // Displaying edge-to-edge
         WindowCompat.setDecorFitsSystemWindows(window, false)
-
-        setContentView(ComposeView(this).apply {
-            // Provide a different ComposeView instead of using ComponentActivity's setContent
-            // method so that the `consumeWindowInsets` property can be set to `false`. This is
-            // needed so that insets can be properly applied to `HomeScreen` which uses View interop
-            // This can likely be changed when `HomeScreen` is fully in Compose.
-            consumeWindowInsets = false
-            setContent {
-                MdcTheme {
-                    SunflowerApp(
+        setContent {
+            MdcTheme {
+                SunflowerApp(
                         onPageChange = { page ->
                             when (page) {
                                 SunflowerPage.MY_GARDEN -> removeMenuProvider(menuProvider)
                                 SunflowerPage.PLANT_LIST -> addMenuProvider(
-                                    menuProvider,
-                                    this@GardenActivity
+                                        menuProvider,
+                                        this@GardenActivity
                                 )
                             }
                         },
                         plantListViewModel = viewModel,
-                    )
-                }
+                )
             }
-        })
+        }
+
+//        setContentView(ComposeView(this).apply {
+//            // Provide a different ComposeView instead of using ComponentActivity's setContent
+//            // method so that the `consumeWindowInsets` property can be set to `false`. This is
+//            // needed so that insets can be properly applied to `HomeScreen` which uses View interop
+//            // This can likely be changed when `HomeScreen` is fully in Compose.
+//            consumeWindowInsets = false
+//        })
     }
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
@@ -35,7 +35,6 @@ import com.google.samples.apps.sunflower.compose.home.SunflowerPage
 import com.google.samples.apps.sunflower.viewmodels.PlantListViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
-// TODO: update the superclass to ComponentActivity https://github.com/android/sunflower/issues/829
 @AndroidEntryPoint
 class GardenActivity : ComponentActivity() {
 

--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/SunflowerApp.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/SunflowerApp.kt
@@ -41,7 +41,6 @@ import com.google.samples.apps.sunflower.viewmodels.PlantListViewModel
 @Composable
 fun SunflowerApp(
     onPageChange: (SunflowerPage) -> Unit = {},
-    onAttached: (Toolbar) -> Unit = {},
     plantListViewModel: PlantListViewModel = hiltViewModel(),
 ) {
     val navController = rememberNavController()
@@ -49,7 +48,6 @@ fun SunflowerApp(
         plantListViewModel = plantListViewModel,
         navController = navController,
         onPageChange = onPageChange,
-        onAttached = onAttached
     )
 }
 
@@ -57,7 +55,6 @@ fun SunflowerApp(
 fun SunFlowerNavHost(
     navController: NavHostController,
     onPageChange: (SunflowerPage) -> Unit = {},
-    onAttached: (Toolbar) -> Unit = {},
     plantListViewModel: PlantListViewModel = hiltViewModel(),
 ) {
     val activity = (LocalContext.current as Activity)
@@ -68,7 +65,6 @@ fun SunFlowerNavHost(
                     navController.navigate("plantDetail/${it.plantId}")
                 },
                 onPageChange = onPageChange,
-                onAttached = onAttached,
                 plantListViewModel = plantListViewModel
             )
         }

--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/garden/GardenScreen.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/garden/GardenScreen.kt
@@ -168,7 +168,7 @@ private fun GardenListItem(
                 text = stringResource(id = R.string.plant_date_header),
                 Modifier.align(Alignment.CenterHorizontally),
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colors.primaryVariant,
+                color = androidx.compose.material3.MaterialTheme.colorScheme.secondary,
                 style = MaterialTheme.typography.subtitle2
             )
             Text(
@@ -184,7 +184,7 @@ private fun GardenListItem(
                     .align(Alignment.CenterHorizontally)
                     .padding(top = marginNormal),
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colors.primaryVariant,
+                color = androidx.compose.material3.MaterialTheme.colorScheme.secondary,
                 style = MaterialTheme.typography.subtitle2
             )
             Text(
@@ -232,7 +232,7 @@ private fun EmptyGarden(onAddPlantClick: () -> Unit, modifier: Modifier = Modifi
             onClick = onAddPlantClick
         ) {
             Text(
-                color = MaterialTheme.colors.primary,
+                color = androidx.compose.material3.MaterialTheme.colorScheme.primary,
                 text = stringResource(id = R.string.add_plant)
             )
         }

--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/home/HomeScreen.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/home/HomeScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Tab
 import androidx.compose.material.TabRow
 import androidx.compose.material.Text
@@ -80,20 +81,25 @@ fun HomeScreen(
     modifier: Modifier = Modifier,
     onPlantClick: (Plant) -> Unit = {},
     onPageChange: (SunflowerPage) -> Unit = {},
-    onAttached: (Toolbar) -> Unit = {},
     plantListViewModel: PlantListViewModel = hiltViewModel()
 ) {
     val activity = (LocalContext.current as AppCompatActivity)
 
     AndroidViewBinding(factory = HomeScreenBinding::inflate, modifier = modifier) {
-        onAttached(toolbar)
         activity.setSupportActionBar(toolbar)
         composeView.setContent {
-            HomePagerScreen(
-                onPlantClick = onPlantClick,
-                onPageChange = onPageChange,
-                plantListViewModel = plantListViewModel
-            )
+            Scaffold(
+                    topBar = {
+
+                    }
+            ) { _ ->
+                HomePagerScreen(
+                        onPlantClick = onPlantClick,
+                        onPageChange = onPageChange,
+                        plantListViewModel = plantListViewModel
+                )
+            }
+
         }
     }
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/home/HomeScreen.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/home/HomeScreen.kt
@@ -18,26 +18,21 @@ package com.google.samples.apps.sunflower.compose.home
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.Toolbar
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Tab
 import androidx.compose.material.TabRow
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -47,96 +42,94 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidViewBinding
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.themeadapter.material.MdcTheme
 import com.google.samples.apps.sunflower.R
 import com.google.samples.apps.sunflower.compose.garden.GardenScreen
 import com.google.samples.apps.sunflower.compose.plantlist.PlantListScreen
+import com.google.samples.apps.sunflower.compose.utils.SunflowerTopBar
 import com.google.samples.apps.sunflower.data.Plant
 import com.google.samples.apps.sunflower.data.PlantAndGardenPlantings
-import com.google.samples.apps.sunflower.databinding.HomeScreenBinding
 import com.google.samples.apps.sunflower.viewmodels.GardenPlantingListViewModel
 import com.google.samples.apps.sunflower.viewmodels.PlantListViewModel
 import kotlinx.coroutines.launch
 
 enum class SunflowerPage(
-    @StringRes val titleResId: Int,
-    @DrawableRes val drawableResId: Int
+        @StringRes val titleResId: Int,
+        @DrawableRes val drawableResId: Int
 ) {
     MY_GARDEN(R.string.my_garden_title, R.drawable.ic_my_garden_active),
     PLANT_LIST(R.string.plant_list_title, R.drawable.ic_plant_list_active)
 }
 
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun HomeScreen(
-    modifier: Modifier = Modifier,
-    onPlantClick: (Plant) -> Unit = {},
-    onPageChange: (SunflowerPage) -> Unit = {},
-    plantListViewModel: PlantListViewModel = hiltViewModel()
+        modifier: Modifier = Modifier,
+        onPlantClick: (Plant) -> Unit = {},
+        onPageChange: (SunflowerPage) -> Unit = {},
+        plantListViewModel: PlantListViewModel = hiltViewModel()
 ) {
-    val activity = (LocalContext.current as AppCompatActivity)
+    val pagerState = rememberPagerState()
 
-    AndroidViewBinding(factory = HomeScreenBinding::inflate, modifier = modifier) {
-        activity.setSupportActionBar(toolbar)
-        composeView.setContent {
-            Scaffold(
-                    topBar = {
-
-                    }
-            ) { _ ->
-                HomePagerScreen(
-                        onPlantClick = onPlantClick,
-                        onPageChange = onPageChange,
-                        plantListViewModel = plantListViewModel
-                )
-            }
-
-        }
+    Scaffold(
+            modifier = Modifier.statusBarsPadding(),
+            topBar = { SunflowerTopBar(pagerState){
+            } },
+            backgroundColor = MaterialTheme.colorScheme.secondary
+    ) { paddingValues ->
+        HomePagerScreen(
+                pagerState =pagerState,
+                onPlantClick = onPlantClick,
+                onPageChange = onPageChange,
+                plantListViewModel = plantListViewModel,
+                modifier = Modifier
+                        .padding(paddingValues)
+        )
     }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun HomePagerScreen(
-    onPlantClick: (Plant) -> Unit,
-    onPageChange: (SunflowerPage) -> Unit,
-    modifier: Modifier = Modifier,
-    pages: Array<SunflowerPage> = SunflowerPage.values(),
-    gardenPlantingListViewModel: GardenPlantingListViewModel = hiltViewModel(),
-    plantListViewModel: PlantListViewModel = hiltViewModel(),
+        pagerState: PagerState,
+        onPlantClick: (Plant) -> Unit,
+        onPageChange: (SunflowerPage) -> Unit,
+        modifier: Modifier = Modifier,
+        pages: Array<SunflowerPage> = SunflowerPage.values(),
+        gardenPlantingListViewModel: GardenPlantingListViewModel = hiltViewModel(),
+        plantListViewModel: PlantListViewModel = hiltViewModel(),
 ) {
     val gardenPlants by gardenPlantingListViewModel.plantAndGardenPlantings.collectAsState(initial = emptyList())
     val plants by plantListViewModel.plants.observeAsState(initial = emptyList())
     HomePagerScreen(
-        onPlantClick = onPlantClick,
-        onPageChange = onPageChange,
-        modifier = modifier,
-        pages = pages,
-        gardenPlants = gardenPlants,
-        plants = plants
+            pagerState = pagerState,
+            onPlantClick = onPlantClick,
+            onPageChange = onPageChange,
+            modifier = modifier,
+            pages = pages,
+            gardenPlants = gardenPlants,
+            plants = plants
     )
 }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun HomePagerScreen(
-    onPlantClick: (Plant) -> Unit,
-    onPageChange: (SunflowerPage) -> Unit,
-    modifier: Modifier = Modifier,
-    pages: Array<SunflowerPage> = SunflowerPage.values(),
-    gardenPlants: List<PlantAndGardenPlantings>,
-    plants: List<Plant>,
+        pagerState: PagerState,
+        onPlantClick: (Plant) -> Unit,
+        onPageChange: (SunflowerPage) -> Unit,
+        modifier: Modifier = Modifier,
+        pages: Array<SunflowerPage> = SunflowerPage.values(),
+        gardenPlants: List<PlantAndGardenPlantings>,
+        plants: List<Plant>,
 ) {
-    val pagerState = rememberPagerState()
 
     LaunchedEffect(pagerState.currentPage) {
         onPageChange(pages[pagerState.currentPage])
@@ -145,55 +138,57 @@ fun HomePagerScreen(
     // Use Modifier.nestedScroll + rememberNestedScrollInteropConnection() here so that this
     // composable participates in the nested scroll hierarchy so that HomeScreen can be used in
     // use cases like a collapsing toolbar
-    Column(modifier.nestedScroll(rememberNestedScrollInteropConnection())) {
+    Column(modifier
+            .nestedScroll(rememberNestedScrollInteropConnection())) {
         val coroutineScope = rememberCoroutineScope()
 
         // Tab Row
-        TabRow(selectedTabIndex = pagerState.currentPage) {
+        TabRow(selectedTabIndex = pagerState.currentPage,
+                backgroundColor = androidx.compose.material3.MaterialTheme.colorScheme.primary) {
             pages.forEachIndexed { index, page ->
                 val title = stringResource(id = page.titleResId)
                 Tab(
-                    selected = pagerState.currentPage == index,
-                    onClick = { coroutineScope.launch { pagerState.animateScrollToPage(index) } },
-                    text = { Text(text = title) },
-                    icon = {
-                        Icon(
-                            painter = painterResource(id = page.drawableResId),
-                            contentDescription = title
-                        )
-                    },
-                    unselectedContentColor = MaterialTheme.colors.primaryVariant,
-                    selectedContentColor = MaterialTheme.colors.secondary,
+                        selected = pagerState.currentPage == index,
+                        onClick = { coroutineScope.launch { pagerState.animateScrollToPage(index) } },
+                        text = { Text(text = title) },
+                        icon = {
+                            Icon(
+                                    painter = painterResource(id = page.drawableResId),
+                                    contentDescription = title
+                            )
+                        },
+                        unselectedContentColor = androidx.compose.material3.MaterialTheme.colorScheme.secondary,
+                        selectedContentColor = androidx.compose.material3.MaterialTheme.colorScheme.tertiary,
                 )
             }
         }
 
         // Pages
         HorizontalPager(
-            pageCount = pages.size,
-            state = pagerState,
-            verticalAlignment = Alignment.Top
+                pageCount = pages.size,
+                state = pagerState,
+                verticalAlignment = Alignment.Top
         ) { index ->
             when (pages[index]) {
                 SunflowerPage.MY_GARDEN -> {
                     GardenScreen(
-                        gardenPlants = gardenPlants,
-                        Modifier.fillMaxSize(),
-                        onAddPlantClick = {
-                            coroutineScope.launch {
-                                pagerState.scrollToPage(SunflowerPage.PLANT_LIST.ordinal)
-                            }
-                        },
-                        onPlantClick = {
-                            onPlantClick(it.plant)
-                        })
+                            gardenPlants = gardenPlants,
+                            Modifier.fillMaxSize(),
+                            onAddPlantClick = {
+                                coroutineScope.launch {
+                                    pagerState.scrollToPage(SunflowerPage.PLANT_LIST.ordinal)
+                                }
+                            },
+                            onPlantClick = {
+                                onPlantClick(it.plant)
+                            })
                 }
 
                 SunflowerPage.PLANT_LIST -> {
                     PlantListScreen(
-                        plants = plants,
-                        onPlantClick = onPlantClick,
-                        modifier = Modifier.fillMaxSize(),
+                            plants = plants,
+                            onPlantClick = onPlantClick,
+                            modifier = Modifier.fillMaxSize(),
                     )
                 }
             }
@@ -201,77 +196,44 @@ fun HomePagerScreen(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun HomeTopAppBar(
-    pagerState: PagerState,
-    onFilterClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    TopAppBar(
-        title = {
-            Row(
-                Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
-            ) {
-                Text(
-                    text = stringResource(id = R.string.app_name)
-                )
-            }
-        },
-        modifier.statusBarsPadding(),
-        actions = {
-            if (pagerState.currentPage == SunflowerPage.PLANT_LIST.ordinal) {
-                IconButton(onClick = onFilterClick) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_filter_list_24dp),
-                        contentDescription = stringResource(
-                            id = R.string.menu_filter_by_grow_zone
-                        ),
-                        tint = MaterialTheme.colors.onPrimary
-                    )
-                }
-            }
-        },
-        elevation = 0.dp
-    )
-}
 
+@OptIn(ExperimentalFoundationApi::class)
 @Preview
 @Composable
 private fun HomeScreenPreview(
-    @PreviewParameter(HomeScreenPreviewParamProvider::class) param: HomePreviewParam
+        @PreviewParameter(HomeScreenPreviewParamProvider::class) param: HomePreviewParam
 ) {
     MdcTheme {
         HomePagerScreen(
-            onPlantClick = {},
-            onPageChange = {},
-            gardenPlants = param.gardenPlants,
-            plants = param.plants
+                pagerState = rememberPagerState(),
+                onPlantClick = {},
+                onPageChange = {},
+                gardenPlants = param.gardenPlants,
+                plants = param.plants
         )
     }
 }
 
 private data class HomePreviewParam(
-    val gardenPlants: List<PlantAndGardenPlantings>,
-    val plants: List<Plant>,
+        val gardenPlants: List<PlantAndGardenPlantings>,
+        val plants: List<Plant>,
 )
 
 private class HomeScreenPreviewParamProvider : PreviewParameterProvider<HomePreviewParam> {
     override val values: Sequence<HomePreviewParam> =
-        sequenceOf(
-            HomePreviewParam(
-                gardenPlants = emptyList(),
-                plants = emptyList()
-            ),
-            HomePreviewParam(
-                gardenPlants = emptyList(),
-                plants = listOf(
-                    Plant("1", "Apple", "Apple", growZoneNumber = 1),
-                    Plant("2", "Banana", "Banana", growZoneNumber = 2),
-                    Plant("3", "Carrot", "Carrot", growZoneNumber = 3),
-                    Plant("4", "Dill", "Dill", growZoneNumber = 3),
-                )
+            sequenceOf(
+                    HomePreviewParam(
+                            gardenPlants = emptyList(),
+                            plants = emptyList()
+                    ),
+                    HomePreviewParam(
+                            gardenPlants = emptyList(),
+                            plants = listOf(
+                                    Plant("1", "Apple", "Apple", growZoneNumber = 1),
+                                    Plant("2", "Banana", "Banana", growZoneNumber = 2),
+                                    Plant("3", "Carrot", "Carrot", growZoneNumber = 3),
+                                    Plant("4", "Dill", "Dill", growZoneNumber = 3),
+                            )
+                    )
             )
-        )
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/plantdetail/PlantDetailView.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/plantdetail/PlantDetailView.kt
@@ -302,7 +302,7 @@ private fun PlantImage(
     imageUrl: String,
     imageHeight: Dp,
     modifier: Modifier = Modifier,
-    placeholderColor: Color = MaterialTheme.colors.onSurface.copy(0.2f)
+    placeholderColor: Color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface.copy(0.2f)
 ) {
     var isLoading by remember { mutableStateOf(true) }
     Box(
@@ -410,7 +410,7 @@ private fun PlantDetailsToolbar(
     Surface {
         TopAppBar(
             modifier = modifier.statusBarsPadding(),
-            backgroundColor = MaterialTheme.colors.surface
+            backgroundColor = androidx.compose.material3.MaterialTheme.colorScheme.surface
         ) {
             IconButton(
                 onBackClick,
@@ -467,7 +467,7 @@ private fun PlantHeaderActions(
                 maxHeight = Dimens.ToolbarIconSize
             )
             .background(
-                color = MaterialTheme.colors.surface,
+                color = androidx.compose.material3.MaterialTheme.colorScheme.surface,
                 shape = CircleShape
             )
 
@@ -540,7 +540,7 @@ private fun PlantInformation(
             Column(Modifier.fillMaxWidth()) {
                 Text(
                     text = stringResource(id = R.string.watering_needs_prefix),
-                    color = MaterialTheme.colors.primaryVariant,
+                    color = androidx.compose.material3.MaterialTheme.colorScheme.secondary,
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier
                         .padding(horizontal = Dimens.PaddingSmall)

--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/theme/Color.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/theme/Color.kt
@@ -1,0 +1,19 @@
+package com.google.samples.apps.sunflower.compose.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Yellow900 = Color(0xFF1a231e)
+val Yellow300 = Color(0xFFf8f99f)
+val Yellow500 = Color(0xFFffff63)
+val YellowGray500 = Color(0x99fafafa)
+val YellowGreen300 = Color(0xFF6dc790)
+val White = Color(0xdeffffff)
+val Black = Color(0xde000000)
+
+val Green500 = Color(0xFF49bb79)
+val Green700 = Color(0xFF005d2b)
+val GreenGray50 = Color(0x99fafafa)
+val GreenYellow500 = Color(0xFFffff63)
+
+
+

--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/theme/Theme.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/theme/Theme.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.sunflower.compose.theme
+
+import android.app.Activity
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Typography
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+
+private val DarkColorScheme = darkColorScheme(
+        primary = Yellow900,
+        secondary = Yellow300,
+        tertiary = YellowGreen300,
+        onPrimary = Yellow300,
+        surface = Black,
+        onSurface = White,
+        inversePrimary = YellowGray500
+)
+
+private val LightColorScheme = lightColorScheme(
+        primary = Green500,
+        secondary = Green700,
+        tertiary = GreenYellow500,
+        onPrimary = Green500,
+        background = Green500,
+        onBackground = Green700,
+        surface = Green700,
+        )
+
+@Composable
+fun SunflowerTheme(
+        darkTheme: Boolean = isSystemInDarkTheme(),
+        // Dynamic color is available on Android 12+
+        dynamicColor: Boolean = false,
+        content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+            window.statusBarColor = android.graphics.Color.TRANSPARENT
+        }
+    }
+
+    MaterialTheme(
+            colorScheme = colorScheme,
+            typography = Typography(),
+            content = content
+    )
+}

--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/utils/SunflowerTopBar.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/utils/SunflowerTopBar.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.sunflower.compose.utils
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.google.samples.apps.sunflower.R
+import com.google.samples.apps.sunflower.compose.home.SunflowerPage
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun SunflowerTopBar(
+        pagerState: PagerState,
+        onFilterClick: () -> Unit
+) {
+    CenterAlignedTopAppBar(
+            title = {
+                Row(
+                        Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                            text = stringResource(id = R.string.app_name)
+                    )
+                }
+            },
+            Modifier.statusBarsPadding(),
+            actions = {
+                if (pagerState.currentPage == SunflowerPage.PLANT_LIST.ordinal) {
+                    IconButton(onClick = onFilterClick) {
+                        Icon(
+                                painter = painterResource(id = R.drawable.ic_filter_list_24dp),
+                                contentDescription = stringResource(
+                                        id = R.string.menu_filter_by_grow_zone
+                                ),
+                                tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+            },
+            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+            )
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,6 +73,7 @@ androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = 
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
 androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout" }
 androidx-compose-material = { module = "androidx.compose.material:material" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }


### PR DESCRIPTION

# Part of [GTC](https://www.facebook.com/groups/gazatechcommunity/) open source initiative 

## As I noticed that #829 is not closed this PR does the following  : 

✅ Update the superclass in GardenActivity to ComponentActivity
✅ update the implementation of the toolbar to use the APIs provided in M3
✅ move Accompanist Theme Adapter, XML theming, and define styles in Kotlin/Compose


