### PR TITLE
Fix: crash when scroll in Gallery Screen

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/gallery/GalleryScreen.kt
@@ -84,7 +84,7 @@ private fun GalleryScreen(
                 count = pagingItems.itemCount,
                 key = { index ->
                     val photo = pagingItems[index]
-                    photo?.id ?: ""
+                    "${ photo?.id ?: ""}${index}"
                 }
             ) { index ->
                 val photo = pagingItems[index] ?: return@items


### PR DESCRIPTION
## Part of [GTC](https://www.facebook.com/groups/gazatechcommunity/) open source initiative

### [#840](https://github.com/android/sunflower/issues/840) Issue :
App Crashes when start scrolling down using LazyVerticalGrid

### ✅ Solution
In Compose when we use key inside items we should make sure that this key is a unique key, so I append the index with the photo.id to make sure that it's unique.



Till next PR 🚀!