### PR TITLE
[Fix] removeReporter App Crashes 

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@
 [versions]
 accessibilityTestFramework = "4.0.0"
 accompanist = "0.28.0"
-activityCompose = "1.7.0"
+activityCompose = "1.7.2"
 androidGradlePlugin = "7.3.1"
 appcompat = "1.6.1"
 benchmark = "1.1.0"


### PR DESCRIPTION
## What?
I've updated the compose activity dependency version to 1.7.2
#853

## Why?
This change prevents the removeReporter() called when all reporters have already been removed exception which causes the app crashes. See #853 for more information.

## How?
The 1.7.2 version prevents this crash by fixing the bug which is caused by onDismiss and observeReporter().



## 

This PR is part of [GTC](https://www.facebook.com/groups/gazatechcommunity/) open source initiative