### PR TITLE
Fix the deprecation of the observe extension method in PlantListFragment

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
@@ -25,7 +25,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.observe
 import com.google.samples.apps.sunflower.adapters.PlantAdapter
 import com.google.samples.apps.sunflower.databinding.FragmentPlantListBinding
 import com.google.samples.apps.sunflower.viewmodels.PlantListViewModel


### PR DESCRIPTION
This PR will fix the deprecation of the observe extension method in PlantListFragment because the observe extension method is no longer required when using Kotlin 1.4. I have fixed it by removing the ` import androidx.lifecycle.observe `. 
[#878](https://github.com/android/sunflower/issues/878)

This PR is part of [GTC](https://www.facebook.com/groups/gazatechcommunity/) open source initiative