### PR TITLE
Fix app bar title alignment to center

### DIFF
--- a/app/src/main/res/layout/fragment_view_pager.xml
+++ b/app/src/main/res/layout/fragment_view_pager.xml
@@ -55,16 +55,16 @@
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
                     app:contentInsetStart="0dp"
-                    app:layout_collapseMode="parallax">
+                    app:layout_collapseMode="parallax" />
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
                     android:gravity="center"
                     android:text="@string/app_name"
-                    android:textAppearance="?attr/textAppearanceHeadline5" />
-
-                </com.google.android.material.appbar.MaterialToolbar>
+                    android:textAppearance="?attr/textAppearanceHeadline5"
+                    android:translationZ="5dp"
+                    app:layout_collapseMode="parallax" />
 
             </com.google.android.material.appbar.CollapsingToolbarLayout>
 


### PR DESCRIPTION
## Issue

If menu icon is added to top app bar, there is a problem that the title are out of alignment

Like this

<img src="https://github.com/android/sunflower/assets/49135657/2eb60f0d-c3ee-49e3-9b9d-0cb0b5745311" width=300/>

## Solution

Take TextView out of Toolbar's child

<img src="https://github.com/android/sunflower/assets/49135657/6e2ea590-3b93-49e7-896a-6228f7f4ae8e" width=300/>


