### PR TITLE
Fix Incorrect packaging.yaml #898 

### DIFF
--- a/.google/packaging.yaml
+++ b/.google/packaging.yaml
@@ -41,7 +41,6 @@ solutions:
   - Flow
   - JetpackHilt
   - JetpackRoom
-  - JetpackDataStore
   - JetpackWorkManager
   - JetpackNavigation
   - JetpackLifecycle


### PR DESCRIPTION
This project doesn't use Jetpack DataStore, but while it had the JetpackDataStore tag it was incorrectly recommended as a hint in the DataStore documentation. 

I remove tag Jetpack DataStore. 