### PR TITLE
feat:Avoid the plantImage not expanding all the way when you swipe up…

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/plantdetail/PlantDetailView.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/plantdetail/PlantDetailView.kt
@@ -219,7 +219,7 @@ fun PlantDetails(
             hasValidUnsplashKey = hasValidUnsplashKey,
             imageHeight = with(LocalDensity.current) {
                 val candidateHeight =
-                    Dimens.PlantDetailAppBarHeight + toolbarOffsetHeightPx.value.toDp()
+                    Dimens.PlantDetailAppBarHeight
                 // FIXME: Remove this workaround when https://github.com/bumptech/glide/issues/4952
                 // is released
                 maxOf(candidateHeight, 1.dp)


### PR DESCRIPTION
Avoid the plantImage not expanding all the way when you swipe up and down quickly.