### PR TITLE
Update HomeScreen.kt

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/home/HomeScreen.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/home/HomeScreen.kt
@@ -168,15 +168,10 @@ private fun HomeTopAppBar(
 ) {
     CenterAlignedTopAppBar(
         title = {
-            Row(
-                Modifier,
-                horizontalArrangement = Arrangement.Center,
-            ) {
                 Text(
                     text = stringResource(id = R.string.app_name),
                     style = MaterialTheme.typography.headlineSmall
                 )
-            }
         },
         modifier = modifier,
         actions = {

--- a/app/src/main/java/com/google/samples/apps/sunflower/compose/home/HomeScreen.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/compose/home/HomeScreen.kt
@@ -169,12 +169,12 @@ private fun HomeTopAppBar(
     CenterAlignedTopAppBar(
         title = {
             Row(
-                Modifier.fillMaxWidth(),
+                Modifier,
                 horizontalArrangement = Arrangement.Center,
             ) {
                 Text(
                     text = stringResource(id = R.string.app_name),
-                    style = MaterialTheme.typography.displaySmall
+                    style = MaterialTheme.typography.headlineSmall
                 )
             }
         },


### PR DESCRIPTION
Removed **_fillMaxWidth()_** from **CenterAlignedTopAppBar's** title because when switching between **My garden** and **Plant list** then  **filter** icon pops up and pushes CenterAlignedTopAppBar to the left

**------------->This is the app before Change**
![Before Change](https://github.com/user-attachments/assets/763db834-45ac-48f6-9c01-6561e0466225)

.
.
.
.
------------->**This is the app after Change**
![After Change](https://github.com/user-attachments/assets/876c27e6-a9ef-499a-88ca-a595ec8f617f)
