### PR TITLE
Update README.md to deprecate Sunflower

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Android Sunflower with Compose
 
+Warning: The Sunflower repository is no longer under maintenance, We are prioritizing https://github.com/android/compose-samples as the up-to-date source of truth for Compose best practises. Please use that repository and sample set to continue learning about Jetpack Compose. If you'd like to continue using Sunflower, we encourage you to maintain your own fork of the sample. 
+
 A gardening app illustrating Android development best practices with migrating a View-based app to
 Jetpack Compose. To learn about how Sunflower was migrated to Compose, see the 
 [migration journey](https://github.com/android/sunflower/blob/main/docs/MigrationJourney.md) document.


### PR DESCRIPTION
We are prioritizing a smaller set of Compose samples.

Please see https://github.com/android/compose-samples for a more up-to-date set of Compose showcases, or https://github.com/android/snippets

We encourage you to fork this sample if you are still finding it valuable for your use case, however - no more updates will be made to this repository.